### PR TITLE
Pass only testId to TaskService::getRemoteTaskIds()

### DIFF
--- a/src/Services/TaskService.php
+++ b/src/Services/TaskService.php
@@ -326,7 +326,7 @@ class TaskService
     }
 
     /**
-     * @param Test $test
+     * @param int $testId
      *
      * @return int[]
      *
@@ -334,12 +334,12 @@ class TaskService
      * @throws InvalidContentTypeException
      * @throws InvalidCredentialsException
      */
-    public function retrieveRemoteTaskIds(Test $test)
+    public function retrieveRemoteTaskIds(int $testId)
     {
         $response = $this->coreApplicationHttpClient->get(
             'test_task_ids',
             [
-                'test_id' => $test->getTestId(),
+                'test_id' => $testId,
             ]
         );
 

--- a/src/Services/TestService.php
+++ b/src/Services/TestService.php
@@ -123,7 +123,7 @@ class TestService
         $this->hydrateFromRemoteTest($test, $remoteTest);
 
         if (in_array($test->getState(), $this->preparedStates) && !$test->hasTaskIds()) {
-            $remoteTaskIds = $this->taskService->retrieveRemoteTaskIds($test);
+            $remoteTaskIds = $this->taskService->retrieveRemoteTaskIds($test->getTestId());
             $test->setTaskIdCollection(implode(',', $remoteTaskIds));
         }
 

--- a/tests/Functional/Services/TaskService/TaskServiceRetrieveRemoteTaskIdsTest.php
+++ b/tests/Functional/Services/TaskService/TaskServiceRetrieveRemoteTaskIdsTest.php
@@ -3,7 +3,6 @@
 
 namespace App\Tests\Functional\Services\TaskService;
 
-use App\Entity\Test;
 use App\Exception\CoreApplicationRequestException;
 use App\Exception\InvalidContentTypeException;
 use App\Exception\InvalidCredentialsException;
@@ -12,17 +11,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class TaskServiceRetrieveRemoteTaskIdsTest extends AbstractTaskServiceTest
 {
-    /**
-     * @var Test
-     */
-    private $test;
-
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->test = Test::create(1, 'http://example.com/');
-    }
+    const TEST_ID = 1;
 
     public function testGetRemoteTaskIdsHttpClientException()
     {
@@ -32,7 +21,7 @@ class TaskServiceRetrieveRemoteTaskIdsTest extends AbstractTaskServiceTest
 
         $this->expectException(CoreApplicationRequestException::class);
 
-        $this->taskService->retrieveRemoteTaskIds($this->test);
+        $this->taskService->retrieveRemoteTaskIds(self::TEST_ID);
     }
 
     public function testGetRemoteTaskInvalidHttpResponse()
@@ -43,7 +32,7 @@ class TaskServiceRetrieveRemoteTaskIdsTest extends AbstractTaskServiceTest
 
         $this->expectException(InvalidContentTypeException::class);
 
-        $this->taskService->retrieveRemoteTaskIds($this->test);
+        $this->taskService->retrieveRemoteTaskIds(self::TEST_ID);
     }
 
     public function testGetRemoteTaskInvalidCredentials()
@@ -54,7 +43,7 @@ class TaskServiceRetrieveRemoteTaskIdsTest extends AbstractTaskServiceTest
 
         $this->expectException(InvalidCredentialsException::class);
 
-        $this->taskService->retrieveRemoteTaskIds($this->test);
+        $this->taskService->retrieveRemoteTaskIds(self::TEST_ID);
     }
 
     /**
@@ -64,7 +53,7 @@ class TaskServiceRetrieveRemoteTaskIdsTest extends AbstractTaskServiceTest
     {
         $this->httpMockHandler->appendFixtures([$httpResponse]);
 
-        $this->assertEquals($expectedTaskIds, $this->taskService->retrieveRemoteTaskIds($this->test));
+        $this->assertEquals($expectedTaskIds, $this->taskService->retrieveRemoteTaskIds(self::TEST_ID));
     }
 
     public function getRemoteTaskIdsSuccessDataProvider(): array


### PR DESCRIPTION
Fixes #788