### PR TITLE
Return TestIdentifier from RemoteTestService::start(), ::retest(), ::retrieveLatest()

### DIFF
--- a/src/Controller/Action/Test/StartController.php
+++ b/src/Controller/Action/Test/StartController.php
@@ -125,14 +125,11 @@ class StartController extends AbstractController
         $urlToTest = $this->getUrlToTest($isFullSiteTest, $website);
 
         try {
-            $remoteTest = $this->remoteTestService->start($urlToTest, $testOptions, $testType);
+            $testIdentifier = $this->remoteTestService->start($urlToTest, $testOptions, $testType);
 
             return new RedirectResponse($this->generateUrl(
                 'view_test_progress',
-                [
-                    'website' => $remoteTest->getWebsite(),
-                    'test_id' => $remoteTest->getId(),
-                ]
+                $testIdentifier->toArray()
             ));
         } catch (CoreApplicationReadOnlyException $coreApplicationReadOnlyException) {
             $this->flashBag->set('test_start_error', 'web_resource_exception');

--- a/src/Controller/Action/Test/TestController.php
+++ b/src/Controller/Action/Test/TestController.php
@@ -141,14 +141,8 @@ class TestController extends AbstractController
      */
     public function retestAction(int $test_id): RedirectResponse
     {
-        $remoteTest = $this->remoteTestService->retest((int) $test_id);
+        $testIdentifier = $this->remoteTestService->retest((int) $test_id);
 
-        return new RedirectResponse($this->generateUrl(
-            'view_test_progress',
-            [
-                'website' => $remoteTest->getWebsite(),
-                'test_id' => $remoteTest->getId(),
-            ]
-        ));
+        return new RedirectResponse($this->generateUrl('view_test_progress', $testIdentifier->toArray()));
     }
 }

--- a/src/Controller/RedirectController.php
+++ b/src/Controller/RedirectController.php
@@ -5,7 +5,6 @@ namespace App\Controller;
 use Psr\Log\LoggerInterface;
 use App\Entity\Test;
 use App\Exception\CoreApplicationRequestException;
-use App\Model\RemoteTest\RemoteTest;
 use App\Services\RemoteTestService;
 use App\Services\TestService;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -67,15 +66,12 @@ class RedirectController extends AbstractController
         $hasTestId = !is_null($normalisedTestId);
 
         if ($hasWebsite && !$hasTestId) {
-            $latestRemoteTest = $remoteTestService->retrieveLatest($normalisedWebsite);
+            $testIdentifier = $remoteTestService->retrieveLatest($normalisedWebsite);
 
-            if ($latestRemoteTest instanceof RemoteTest) {
+            if ($testIdentifier) {
                 return new RedirectResponse($this->generateUrl(
                     'redirect_website_test',
-                    [
-                        'website' => $latestRemoteTest->getWebsite(),
-                        'test_id' => $latestRemoteTest->getId()
-                    ]
+                    $testIdentifier->toArray()
                 ));
             }
         }

--- a/src/Services/RemoteTestService.php
+++ b/src/Services/RemoteTestService.php
@@ -8,6 +8,7 @@ use App\Exception\CoreApplicationRequestException;
 use App\Exception\InvalidContentTypeException;
 use App\Exception\InvalidCredentialsException;
 use App\Model\RemoteTest\RemoteTest;
+use App\Model\TestIdentifier;
 use App\Model\TestOptions;
 
 class RemoteTestService
@@ -31,7 +32,7 @@ class RemoteTestService
      * @param TestOptions $testOptions
      * @param string $testType
      *
-     * @return RemoteTest
+     * @return TestIdentifier
      *
      * @throws CoreApplicationReadOnlyException
      * @throws CoreApplicationRequestException
@@ -42,7 +43,7 @@ class RemoteTestService
         string $canonicalUrl,
         TestOptions $testOptions,
         string $testType = Test::TYPE_FULL_SITE
-    ): RemoteTest {
+    ): TestIdentifier {
         if ($testOptions->hasFeatureOptions('cookies')) {
             $cookieDomain = $this->registerableDomainService->getRegisterableDomain($canonicalUrl);
 
@@ -67,7 +68,10 @@ class RemoteTestService
 
         $responseData = $this->jsonResponseHandler->handle($response);
 
-        return new RemoteTest($responseData);
+        return new TestIdentifier(
+            $responseData['id'],
+            $responseData['website']
+        );
     }
 
     private function setCustomCookieDomain(TestOptions $testOptions, string $domain)

--- a/src/Services/RemoteTestService.php
+++ b/src/Services/RemoteTestService.php
@@ -241,9 +241,9 @@ class RemoteTestService
         return $finishedCount;
     }
 
-    public function retrieveLatest(string $canonicalUrl): ?RemoteTest
+    public function retrieveLatest(string $canonicalUrl): ?TestIdentifier
     {
-        $remoteTest = null;
+        $testIdentifier = null;
 
         try {
             $response = $this->coreApplicationHttpClient->get(
@@ -253,9 +253,12 @@ class RemoteTestService
                 ]
             );
 
-            $remoteTestData = $this->jsonResponseHandler->handle($response);
+            $responseData = $this->jsonResponseHandler->handle($response);
 
-            $remoteTest = new RemoteTest($remoteTestData);
+            $testIdentifier = new TestIdentifier(
+                $responseData['id'],
+                $responseData['website']
+            );
         } catch (CoreApplicationRequestException $coreApplicationRequestException) {
             // Don't care
         } catch (InvalidContentTypeException $invalidContentTypeException) {
@@ -264,6 +267,6 @@ class RemoteTestService
             // Don't care
         }
 
-        return $remoteTest;
+        return $testIdentifier;
     }
 }

--- a/src/Services/RemoteTestService.php
+++ b/src/Services/RemoteTestService.php
@@ -154,14 +154,14 @@ class RemoteTestService
     /**
      * @param int $testId
      *
-     * @return RemoteTest
+     * @return TestIdentifier
      *
      * @throws CoreApplicationReadOnlyException
      * @throws CoreApplicationRequestException
      * @throws InvalidContentTypeException
      * @throws InvalidCredentialsException
      */
-    public function retest(int $testId): RemoteTest
+    public function retest(int $testId): TestIdentifier
     {
         $response = $this->coreApplicationHttpClient->post(
             'test_retest',
@@ -172,7 +172,10 @@ class RemoteTestService
 
         $responseData = $this->jsonResponseHandler->handle($response);
 
-        return new RemoteTest($responseData);
+        return new TestIdentifier(
+            $responseData['id'],
+            $responseData['website']
+        );
     }
 
     public function lock(int $testId)

--- a/tests/Functional/Controller/Action/Test/StartControllerTest.php
+++ b/tests/Functional/Controller/Action/Test/StartControllerTest.php
@@ -4,10 +4,10 @@
 namespace App\Tests\Functional\Controller\Action\Test;
 
 use App\Entity\Test;
+use App\Model\TestIdentifier;
 use GuzzleHttp\Psr7\Response;
 use Mockery\Mock;
 use App\Controller\Action\Test\StartController;
-use App\Model\RemoteTest\RemoteTest;
 use App\Services\Configuration\LinkIntegrityTestConfiguration;
 use App\Services\Configuration\TestOptionsConfiguration;
 use App\Services\RemoteTestService;
@@ -566,10 +566,10 @@ class StartControllerTest extends AbstractControllerTest
 
                 return true;
             })
-            ->andReturn(new RemoteTest([
-                'id' => 1,
-                'website' => $expectedUrlToTest,
-            ]));
+            ->andReturn(new TestIdentifier(
+                1,
+                $expectedUrlToTest
+            ));
 
         $testStartController = new StartController(
             $router,

--- a/tests/Functional/Controller/RedirectControllerTest.php
+++ b/tests/Functional/Controller/RedirectControllerTest.php
@@ -4,7 +4,7 @@
 namespace App\Tests\Functional\Controller;
 
 use App\Exception\CoreApplicationRequestException;
-use App\Model\RemoteTest\RemoteTest;
+use App\Model\TestIdentifier;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
@@ -164,10 +164,7 @@ class RedirectControllerTest extends AbstractControllerTest
 
     public function testTestActionWebsiteOnlyUsesLatest()
     {
-        $latestRemoteTest = new RemoteTest([
-            'id' => 99,
-            'website' => self::WEBSITE,
-        ]);
+        $testIdentifier = new TestIdentifier(99, self::WEBSITE);
 
         /* @var TestService $testService */
         $testService = self::$container->get(TestService::class);
@@ -176,7 +173,7 @@ class RedirectControllerTest extends AbstractControllerTest
         $remoteTestService
             ->shouldReceive('retrieveLatest')
             ->with(self::WEBSITE)
-            ->andReturn($latestRemoteTest);
+            ->andReturn($testIdentifier);
 
         /* @var LoggerInterface $logger */
         $logger = self::$container->get(LoggerInterface::class);

--- a/tests/Functional/Services/RemoteTestService/RemoteTestServiceRetestTest.php
+++ b/tests/Functional/Services/RemoteTestService/RemoteTestServiceRetestTest.php
@@ -3,13 +3,14 @@
 namespace App\Tests\Functional\Services\RemoteTestService;
 
 use App\Entity\Test;
-use App\Model\RemoteTest\RemoteTest;
+use App\Model\TestIdentifier;
 use App\Tests\Factory\HttpResponseFactory;
 
 class RemoteTestServiceRetestTest extends AbstractRemoteTestServiceTest
 {
     const TEST_ID = 1;
     const NEW_TEST_ID = 2;
+    const WEBSITE = 'http://example.com/';
 
     /**
      * @var Test
@@ -28,16 +29,24 @@ class RemoteTestServiceRetestTest extends AbstractRemoteTestServiceTest
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createJsonResponse([
                 'id' => self::NEW_TEST_ID,
+                'website' => self::WEBSITE,
             ]),
         ]);
     }
 
     public function testRetest()
     {
-        $remoteTest = $this->remoteTestService->retest($this->test->getTestId());
+        $testIdentifier = $this->remoteTestService->retest($this->test->getTestId());
 
-        $this->assertInstanceOf(RemoteTest::class, $remoteTest);
-        $this->assertEquals(self::NEW_TEST_ID, $remoteTest->getId());
+        $this->assertInstanceOf(TestIdentifier::class, $testIdentifier);
+
+        $this->assertEquals(
+            [
+                'test_id' => self::NEW_TEST_ID,
+                'website' => self::WEBSITE,
+            ],
+            $testIdentifier->toArray()
+        );
 
         $this->assertEquals(
             'http://null/job/1/re-test/',

--- a/tests/Functional/Services/RemoteTestService/RemoteTestServiceRetrieveLatestTest.php
+++ b/tests/Functional/Services/RemoteTestService/RemoteTestServiceRetrieveLatestTest.php
@@ -3,7 +3,7 @@
 
 namespace App\Tests\Functional\Services\RemoteTestService;
 
-use App\Model\RemoteTest\RemoteTest;
+use App\Model\TestIdentifier;
 use App\Tests\Factory\ConnectExceptionFactory;
 use App\Tests\Factory\HttpResponseFactory;
 
@@ -17,13 +17,13 @@ class RemoteTestServiceRetrieveLatestTest extends AbstractRemoteTestServiceTest
     public function testRetrieveLatest(
         array $httpFixtures,
         ?string $expectedRequestUrl,
-        ?RemoteTest $expectedLatestTest
+        ?TestIdentifier $expectedTestIdentifier
     ) {
         $this->httpMockHandler->appendFixtures($httpFixtures);
 
-        $remoteTest = $this->remoteTestService->retrieveLatest(self::WEBSITE_URL);
+        $testIdentifier = $this->remoteTestService->retrieveLatest(self::WEBSITE_URL);
 
-        $this->assertEquals($expectedLatestTest, $remoteTest);
+        $this->assertEquals($expectedTestIdentifier, $testIdentifier);
 
         if (!is_null($expectedRequestUrl)) {
             $this->assertEquals(
@@ -35,10 +35,6 @@ class RemoteTestServiceRetrieveLatestTest extends AbstractRemoteTestServiceTest
 
     public function retrieveLatestDataProvider(): array
     {
-        $remoteTest = new RemoteTest([
-            'id' => 1,
-        ]);
-
         $curlTimeoutConnectException = ConnectExceptionFactory::create(28, 'Operation timed out');
 
         return [
@@ -47,7 +43,7 @@ class RemoteTestServiceRetrieveLatestTest extends AbstractRemoteTestServiceTest
                     HttpResponseFactory::createNotFoundResponse(),
                 ],
                 'expectedRequestUrl' => 'http://null/job/http%3A%2F%2Fexample.com%2F/latest/',
-                'expectedLatestTest' => null,
+                'expectedTestIdentifier' => null,
             ],
 
             'CURL 28' => [
@@ -60,7 +56,7 @@ class RemoteTestServiceRetrieveLatestTest extends AbstractRemoteTestServiceTest
                     $curlTimeoutConnectException,
                 ],
                 'expectedRequestUrl' => null,
-                'expectedLatestTest' => null,
+                'expectedTestIdentifier' => null,
             ],
             'Invalid response content' => [
                 'httpFixtures' => [
@@ -69,16 +65,17 @@ class RemoteTestServiceRetrieveLatestTest extends AbstractRemoteTestServiceTest
                     ]),
                 ],
                 'expectedRequestUrl' => 'http://null/job/http%3A%2F%2Fexample.com%2F/latest/',
-                'expectedLatestTest' => null,
+                'expectedTestIdentifier' => null,
             ],
             'Success' => [
                 'httpFixtures' => [
                     HttpResponseFactory::createJsonResponse([
-                        'id' => 1
+                        'id' => 1,
+                        'website' => 'http://example.com/',
                     ]),
                 ],
                 'expectedRequestUrl' => 'http://null/job/http%3A%2F%2Fexample.com%2F/latest/',
-                'expectedLatestTest' => $remoteTest,
+                'expectedTestIdentifier' => new TestIdentifier(1, 'http://example.com/'),
             ],
         ];
     }

--- a/tests/Functional/Services/RemoteTestService/RemoteTestServiceStartTest.php
+++ b/tests/Functional/Services/RemoteTestService/RemoteTestServiceStartTest.php
@@ -8,7 +8,7 @@ use App\Exception\CoreApplicationReadOnlyException;
 use App\Exception\CoreApplicationRequestException;
 use App\Exception\InvalidContentTypeException;
 use App\Exception\InvalidCredentialsException;
-use App\Model\RemoteTest\RemoteTest;
+use App\Model\TestIdentifier;
 use App\Model\TestOptions;
 use App\Tests\Factory\HttpResponseFactory;
 use App\Tests\Factory\ModelFactory;
@@ -103,15 +103,16 @@ class RemoteTestServiceStartTest extends AbstractRemoteTestServiceTest
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createJsonResponse([
                 'id' => 1,
+                'website' => 'http://example.com/',
             ]),
         ]);
 
-        $remoteTest = $this->remoteTestService->start(
+        $testIdentifier = $this->remoteTestService->start(
             $url,
             $testOptions
         );
 
-        $this->assertInstanceOf(RemoteTest::class, $remoteTest);
+        $this->assertInstanceOf(TestIdentifier::class, $testIdentifier);
 
         $lastRequest = $this->httpHistory->getLastRequest();
 


### PR DESCRIPTION
Fixes #826 
Fixes #827 
Fixes #828 