### PR TITLE
Use RemoteTestService::isAuthorised() in RequiresValidTestOwnerRequestListener

### DIFF
--- a/src/EventListener/RequiresValidTestOwnerRequestListener.php
+++ b/src/EventListener/RequiresValidTestOwnerRequestListener.php
@@ -2,6 +2,7 @@
 
 namespace App\EventListener;
 
+use App\Services\RemoteTestService;
 use App\Services\RequiresValidTestOwnerResponseProvider;
 use App\Services\TestService;
 use App\Services\UrlMatcherInterface;
@@ -16,19 +17,22 @@ class RequiresValidTestOwnerRequestListener
     private $userManager;
     private $flashBag;
     private $testService;
+    private $remoteTestService;
 
     public function __construct(
         UrlMatcherInterface $urlMatcher,
         RequiresValidTestOwnerResponseProvider $requiresValidTestOwnerResponseProvider,
         UserManager $userManager,
         FlashBagInterface $flashBag,
-        TestService $testService
+        TestService $testService,
+        RemoteTestService $remoteTestService
     ) {
         $this->urlMatcher = $urlMatcher;
         $this->requiresValidTestOwnerResponseProvider = $requiresValidTestOwnerResponseProvider;
         $this->userManager = $userManager;
         $this->flashBag = $flashBag;
         $this->testService = $testService;
+        $this->remoteTestService = $remoteTestService;
     }
 
     /**
@@ -47,7 +51,7 @@ class RequiresValidTestOwnerRequestListener
         $requestAttributes = $request->attributes;
         $testId = (int) $requestAttributes->get('test_id');
 
-        if ($requiresValidTestOwner && !$this->testService->get($testId)) {
+        if ($requiresValidTestOwner && !$this->remoteTestService->isAuthorised($testId)) {
             $response = $this->requiresValidTestOwnerResponseProvider->getResponse($request);
 
             if (!empty($response)) {

--- a/tests/Functional/Controller/View/Partials/TestFinishedSummaryControllerTest.php
+++ b/tests/Functional/Controller/View/Partials/TestFinishedSummaryControllerTest.php
@@ -94,6 +94,7 @@ class TestFinishedSummaryControllerTest extends AbstractViewControllerTest
     {
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createSuccessResponse(),
+            HttpResponseFactory::createJsonResponse(true),
             HttpResponseFactory::createJsonResponse($this->remoteTestData),
         ]);
 
@@ -104,6 +105,7 @@ class TestFinishedSummaryControllerTest extends AbstractViewControllerTest
 
         /* @var Response $response */
         $response = $this->client->getResponse();
+
         $this->assertTrue($response->isSuccessful());
     }
 

--- a/tests/Functional/Controller/View/Partials/TestTaskListControllerTest.php
+++ b/tests/Functional/Controller/View/Partials/TestTaskListControllerTest.php
@@ -98,6 +98,7 @@ class TestTaskListControllerTest extends AbstractViewControllerTest
     {
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createSuccessResponse(),
+            HttpResponseFactory::createJsonResponse(true),
             HttpResponseFactory::createJsonResponse($this->remoteTestData),
             HttpResponseFactory::createJsonResponse([]),
             HttpResponseFactory::createJsonResponse([$this->remoteTaskData]),
@@ -120,6 +121,7 @@ class TestTaskListControllerTest extends AbstractViewControllerTest
         $this->assertEquals(
             [
                 'http://null/user/public/authenticate/',
+                'http://null/job/1/is-authorised/',
                 'http://null/job/1/',
                 'http://null/job/1/tasks/ids/',
                 'http://null/job/1/tasks/',

--- a/tests/Functional/Controller/View/Partials/TestUrlLimitNotificationControllerTest.php
+++ b/tests/Functional/Controller/View/Partials/TestUrlLimitNotificationControllerTest.php
@@ -83,6 +83,7 @@ class TestUrlLimitNotificationControllerTest extends AbstractViewControllerTest
 
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createSuccessResponse(),
+            HttpResponseFactory::createJsonResponse(true),
             HttpResponseFactory::createJsonResponse($remoteTestData),
             HttpResponseFactory::createJsonResponse([]),
         ]);

--- a/tests/Functional/Controller/View/Task/ResultsControllerTest.php
+++ b/tests/Functional/Controller/View/Task/ResultsControllerTest.php
@@ -160,6 +160,7 @@ class ResultsControllerTest extends AbstractViewControllerTest
     {
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createSuccessResponse(),
+            HttpResponseFactory::createJsonResponse(true),
             HttpResponseFactory::createJsonResponse($this->remoteTestData),
             HttpResponseFactory::createJsonResponse([]),
             HttpResponseFactory::createJsonResponse([$this->remoteTaskData]),
@@ -182,6 +183,7 @@ class ResultsControllerTest extends AbstractViewControllerTest
     {
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createSuccessResponse(),
+            HttpResponseFactory::createJsonResponse(true),
             HttpResponseFactory::createJsonResponse($this->remoteTestData),
             HttpResponseFactory::createJsonResponse([]),
             HttpResponseFactory::createJsonResponse([$this->remoteTaskData]),
@@ -200,6 +202,7 @@ class ResultsControllerTest extends AbstractViewControllerTest
         $this->assertEquals(
             [
                 'http://null/user/public/authenticate/',
+                'http://null/job/1/is-authorised/',
                 'http://null/job/1/',
                 'http://null/job/1/tasks/ids/',
                 'http://null/job/1/tasks/',
@@ -866,6 +869,7 @@ class ResultsControllerTest extends AbstractViewControllerTest
     {
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createSuccessResponse(),
+            HttpResponseFactory::createJsonResponse(true),
             HttpResponseFactory::createJsonResponse($this->remoteTestData),
             HttpResponseFactory::createJsonResponse([]),
             HttpResponseFactory::createJsonResponse([

--- a/tests/Functional/Controller/View/Test/ProgressControllerTest.php
+++ b/tests/Functional/Controller/View/Test/ProgressControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 /** @noinspection PhpDocSignatureInspection */
 
-namespace App\Tests\Functional\Controller\View\Test\Progress;
+namespace App\Tests\Functional\Controller\View\Test;
 
 use App\Controller\View\Test\ProgressController;
 use App\Entity\Task\Task;
@@ -130,6 +130,7 @@ class ProgressControllerTest extends AbstractViewControllerTest
     {
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createSuccessResponse(),
+            HttpResponseFactory::createJsonResponse(true),
             HttpResponseFactory::createJsonResponse($this->remoteTestData),
             HttpResponseFactory::createJsonResponse([]),
         ]);
@@ -147,6 +148,7 @@ class ProgressControllerTest extends AbstractViewControllerTest
         $this->assertEquals(
             [
                 'http://null/user/public/authenticate/',
+                'http://null/job/1/is-authorised/',
                 'http://null/job/1/',
                 'http://null/job/1/tasks/ids/',
             ],

--- a/tests/Functional/Controller/View/Test/Results/ByTaskTypeControllerTest.php
+++ b/tests/Functional/Controller/View/Test/Results/ByTaskTypeControllerTest.php
@@ -127,6 +127,7 @@ class ByTaskTypeControllerTest extends AbstractViewControllerTest
             'incomplete test' => [
                 'httpFixtures' => [
                     HttpResponseFactory::createSuccessResponse(),
+                    HttpResponseFactory::createJsonResponse(true),
                     HttpResponseFactory::createJsonResponse(array_merge($this->remoteTestData, [
                         'state' => Test::STATE_IN_PROGRESS,
                     ])),
@@ -137,6 +138,7 @@ class ByTaskTypeControllerTest extends AbstractViewControllerTest
             'website mismatch' => [
                 'httpFixtures' => [
                     HttpResponseFactory::createSuccessResponse(),
+                    HttpResponseFactory::createJsonResponse(true),
                     HttpResponseFactory::createJsonResponse(array_merge($this->remoteTestData, [
                         'website' => 'http://foo.example.com/',
                     ])),
@@ -177,6 +179,7 @@ class ByTaskTypeControllerTest extends AbstractViewControllerTest
     {
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createSuccessResponse(),
+            HttpResponseFactory::createJsonResponse(true),
             HttpResponseFactory::createJsonResponse($this->remoteTestData),
             HttpResponseFactory::createJsonResponse([1,]),
         ]);
@@ -203,6 +206,7 @@ class ByTaskTypeControllerTest extends AbstractViewControllerTest
         $this->assertEquals(
             [
                 'http://null/user/public/authenticate/',
+                'http://null/job/1/is-authorised/',
                 'http://null/job/1/',
                 'http://null/job/1/tasks/ids/',
             ],

--- a/tests/Functional/Controller/View/Test/Results/FailedNoUrlsDetectedControllerTest.php
+++ b/tests/Functional/Controller/View/Test/Results/FailedNoUrlsDetectedControllerTest.php
@@ -77,6 +77,7 @@ class FailedNoUrlsDetectedControllerTest extends AbstractViewControllerTest
     {
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createSuccessResponse(),
+            HttpResponseFactory::createJsonResponse(true),
             HttpResponseFactory::createJsonResponse($this->remoteTestData),
         ]);
 
@@ -92,6 +93,7 @@ class FailedNoUrlsDetectedControllerTest extends AbstractViewControllerTest
         $this->assertEquals(
             [
                 'http://null/user/public/authenticate/',
+                'http://null/job/1/is-authorised/',
                 'http://null/job/1/',
             ],
             $this->httpHistory->getRequestUrlsAsStrings()

--- a/tests/Functional/Controller/View/Test/Results/PreparingControllerTest.php
+++ b/tests/Functional/Controller/View/Test/Results/PreparingControllerTest.php
@@ -99,6 +99,7 @@ class PreparingControllerTest extends AbstractViewControllerTest
     {
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createSuccessResponse(),
+            HttpResponseFactory::createJsonResponse(true),
             HttpResponseFactory::createJsonResponse($this->remoteTestData),
             HttpResponseFactory::createJsonResponse([1, 2, 3,]),
         ]);
@@ -115,6 +116,7 @@ class PreparingControllerTest extends AbstractViewControllerTest
         $this->assertEquals(
             [
                 'http://null/user/public/authenticate/',
+                'http://null/job/1/is-authorised/',
                 'http://null/job/1/',
                 'http://null/job/1/tasks/ids/',
             ],

--- a/tests/Functional/Controller/View/Test/Results/PreparingStatsControllerTest.php
+++ b/tests/Functional/Controller/View/Test/Results/PreparingStatsControllerTest.php
@@ -93,6 +93,7 @@ class PreparingStatsControllerTest extends AbstractViewControllerTest
     {
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createSuccessResponse(),
+            HttpResponseFactory::createJsonResponse(true),
             HttpResponseFactory::createJsonResponse($this->remoteTestData),
             HttpResponseFactory::createJsonResponse([]),
         ]);

--- a/tests/Functional/Controller/View/Test/Results/RejectedControllerTest.php
+++ b/tests/Functional/Controller/View/Test/Results/RejectedControllerTest.php
@@ -170,6 +170,7 @@ class RejectedControllerTest extends AbstractViewControllerTest
     ) {
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createSuccessResponse(),
+            HttpResponseFactory::createJsonResponse(true),
             HttpResponseFactory::createJsonResponse($remoteTestData),
             HttpResponseFactory::createJsonResponse($userData),
         ]);
@@ -197,6 +198,7 @@ class RejectedControllerTest extends AbstractViewControllerTest
         $this->assertEquals(
             [
                 'http://null/user/public/authenticate/',
+                'http://null/job/1/is-authorised/',
                 'http://null/job/1/',
                 'http://null/user/public/',
             ],

--- a/tests/Functional/Controller/View/Test/Results/ResultsControllerTest.php
+++ b/tests/Functional/Controller/View/Test/Results/ResultsControllerTest.php
@@ -156,6 +156,7 @@ class ResultsControllerTest extends AbstractViewControllerTest
             'incomplete test' => [
                 'httpFixtures' => [
                     HttpResponseFactory::createSuccessResponse(),
+                    HttpResponseFactory::createJsonResponse(true),
                     HttpResponseFactory::createJsonResponse(array_merge($this->remoteTestData, [
                         'state' => Test::STATE_IN_PROGRESS,
                     ])),
@@ -166,6 +167,7 @@ class ResultsControllerTest extends AbstractViewControllerTest
             'website mismatch' => [
                 'httpFixtures' => [
                     HttpResponseFactory::createSuccessResponse(),
+                    HttpResponseFactory::createJsonResponse(true),
                     HttpResponseFactory::createJsonResponse(array_merge($this->remoteTestData, [
                         'website' => 'http://foo.example.com/',
                     ])),
@@ -179,6 +181,7 @@ class ResultsControllerTest extends AbstractViewControllerTest
             'failed test' => [
                 'httpFixtures' => [
                     HttpResponseFactory::createSuccessResponse(),
+                    HttpResponseFactory::createJsonResponse(true),
                     HttpResponseFactory::createJsonResponse(array_merge($this->remoteTestData, [
                         'state' => Test::STATE_FAILED_NO_SITEMAP,
                     ])),
@@ -189,6 +192,7 @@ class ResultsControllerTest extends AbstractViewControllerTest
             'rejected test' => [
                 'httpFixtures' => [
                     HttpResponseFactory::createSuccessResponse(),
+                    HttpResponseFactory::createJsonResponse(true),
                     HttpResponseFactory::createJsonResponse(array_merge($this->remoteTestData, [
                         'state' => Test::STATE_REJECTED,
                     ])),
@@ -252,6 +256,7 @@ class ResultsControllerTest extends AbstractViewControllerTest
         $this->assertEquals(
             [
                 'http://null/user/public/authenticate/',
+                'http://null/job/1/is-authorised/',
                 'http://null/job/1/',
                 'http://null/job/1/tasks/ids/',
             ],
@@ -268,6 +273,7 @@ class ResultsControllerTest extends AbstractViewControllerTest
                 'filter' => ResultsController::FILTER_WITH_ERRORS,
                 'httpFixtures' => [
                     HttpResponseFactory::createSuccessResponse(),
+                    HttpResponseFactory::createJsonResponse(true),
                     HttpResponseFactory::createJsonResponse($this->remoteTestData),
                     HttpResponseFactory::createJsonResponse([1, 2, 3, 4, ]),
                 ],
@@ -279,6 +285,7 @@ class ResultsControllerTest extends AbstractViewControllerTest
                 'filter' => ResultsController::FILTER_WITH_ERRORS,
                 'httpFixtures' => [
                     HttpResponseFactory::createSuccessResponse(),
+                    HttpResponseFactory::createJsonResponse(true),
                     HttpResponseFactory::createJsonResponse(array_merge($this->remoteTestData, [
                         'website' => 'http://example.com/articles/foo/bar/6875374/foobar/',
                     ])),
@@ -294,6 +301,7 @@ class ResultsControllerTest extends AbstractViewControllerTest
     {
         $this->httpMockHandler->appendFixtures([
             HttpResponseFactory::createSuccessResponse(),
+            HttpResponseFactory::createJsonResponse(true),
             HttpResponseFactory::createJsonResponse($this->remoteTestData),
             HttpResponseFactory::createJsonResponse([1, 2, 3, 4, ]),
         ]);


### PR DESCRIPTION
Fixes #905